### PR TITLE
Python "FutureWarnings" in EE2 Standards

### DIFF
--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -194,6 +194,8 @@ See `Appendix A: Workflow Examples`_ for examples of these utilities in use.
   If ``$err`` is non-zero, the job is aborted.
   ``err_exit`` will write an error message with the time of the error, and immediately abort the job in PBS Pro.
   It accepts an error string as input to which it will prepend “FATAL ERROR.”
+  Python “FutureWarning” messages, which indicate that a job may fail in the future due to incompatible Python packages, are acceptable.
+  Developers should attempt to resolve “FutureWarning” messages as soon as possible to prevent jobs failing in future package upgrades.  
 
 ``cpreq``
   ``cpreq`` is used to copy files that are essential to an application.

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -194,9 +194,6 @@ See `Appendix A: Workflow Examples`_ for examples of these utilities in use.
   If ``$err`` is non-zero, the job is aborted.
   ``err_exit`` will write an error message with the time of the error, and immediately abort the job in PBS Pro.
   It accepts an error string as input to which it will prepend “FATAL ERROR.”
-  Python “FutureWarning” messages indicate that a specific feature, function, or syntax that is currently being used will be changed or removed in a future version of Python or in a future version of a Python library. 
-  Python “FutureWarning” messages are acceptable messages in operations and should not be suppressed.
-  Developers should make an effort to resolve “FutureWarning” messages, when possible, in order to prevent production jobs from failing in the future.  
 
 ``cpreq``
   ``cpreq`` is used to copy files that are essential to an application.
@@ -626,6 +623,7 @@ Please also observe the following points:
 * All packages that use Python scripts must specify a Python version through the module system, and must only call a Python executable that is from a module, not the system version.
 * "``module load python/${python_ver:?}``" or similar must be present in all job files that will lead to python script calls, where the python version is defined in the version file.
 * Python version must be at version 3 or higher.
+* Python “FutureWarning” messages indicate that a specific feature, function, or syntax that is currently being used will be changed or removed in a future version of Python or in a future version of a Python library. Python “FutureWarning” messages are acceptable messages in operations and should not be suppressed. Developers should make an effort to resolve “FutureWarning” messages, when possible, in order to prevent production jobs from failing in the future. 
 
 Reference `Appendix A: Workflow Examples`_ for commented examples of a version file, ecFlow script, J-job, ex-script, modulefile and makefile.
 

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -194,8 +194,9 @@ See `Appendix A: Workflow Examples`_ for examples of these utilities in use.
   If ``$err`` is non-zero, the job is aborted.
   ``err_exit`` will write an error message with the time of the error, and immediately abort the job in PBS Pro.
   It accepts an error string as input to which it will prepend “FATAL ERROR.”
-  Python “FutureWarning” messages, which indicate that a job may fail in the future due to incompatible Python packages, are acceptable messages.
-  Developers should attempt to resolve “FutureWarning” messages, when possible, to prevent jobs from failing in future operational package upgrades.  
+  Python “FutureWarning” messages indicate that a specific feature, function, or syntax that is currently being used will be changed or removed in a future version of Python or in a future version of a Python library. 
+  Python “FutureWarning” messages are acceptable messages in operations and should not be suppressed.
+  Developers should make an effort to resolve “FutureWarning” messages, when possible, in order to prevent production jobs from failing in the future.  
 
 ``cpreq``
   ``cpreq`` is used to copy files that are essential to an application.

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -194,8 +194,8 @@ See `Appendix A: Workflow Examples`_ for examples of these utilities in use.
   If ``$err`` is non-zero, the job is aborted.
   ``err_exit`` will write an error message with the time of the error, and immediately abort the job in PBS Pro.
   It accepts an error string as input to which it will prepend “FATAL ERROR.”
-  Python “FutureWarning” messages, which indicate that a job may fail in the future due to incompatible Python packages, are acceptable.
-  Developers should attempt to resolve “FutureWarning” messages as soon as possible to prevent jobs failing in future package upgrades.  
+  Python “FutureWarning” messages, which indicate that a job may fail in the future due to incompatible Python packages, are acceptable messages.
+  Developers should attempt to resolve “FutureWarning” messages, when possible, to prevent jobs from failing in future operational package upgrades.  
 
 ``cpreq``
   ``cpreq`` is used to copy files that are essential to an application.


### PR DESCRIPTION
As more production packages use Python, we are going to start seeing Python "FutureWarning" messages in operational log files. Python "FutureWarning" messages do not indicate a current problem with the production code–they warn about a Python or Python package incompatibility that may cause jobs to fail _when a future version of Python or the Python library is used._ 

Python "FutureWarning" messages should be considered acceptable during the EE2 Review process and in operational log files. Developers should make an effort to address the underlying cause of "FutureWarning" messages, when possible, to prevent jobs from failing in the future. I'd like the EE2 Standards document updated to reflect this. 

Please feel free to suggest changes to the wording that I used in this PR. Thanks!

CC @JacobCarley-NOAA @aerorahul @JustinCooke-NCO