### PR TITLE
remove job 'Upload warnings (on failure)'; update URL providing path to sample build of PR

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -70,13 +70,13 @@ jobs:
         path: docs/_build/latex/ee-docs.pdf
         if-no-files-found: ignore
 
-    - name: Upload warnings (on failure)
-      uses: actions/upload-artifact@v4
-      if: failure()
-      with:
-        name: ee-docs.warnings.log
-        path: docs/_build/warnings.log
-        if-no-files-found: ignore
+#    - name: Upload warnings (on failure)
+#      uses: actions/upload-artifact@v4
+#      if: failure()
+#      with:
+#        name: ee-docs.warnings.log
+#        path: docs/_build/warnings.log
+#        if-no-files-found: ignore
 
     - name: Comment ReadDocs Link in PR
       if: ${{ github.event_name == 'pull_request' }}
@@ -85,7 +85,7 @@ jobs:
         script: |
           const message = `
           Link to ReadTheDocs sample build for this PR can be found at:
-          https://eedocs.org.readthedocs.build/en/${{ github.event.pull_request.number }}
+          https://nws-hpc-standards--${{ github.event.pull_request.number }}.org.readthedocs.build/en/${{ github.event.pull_request.number }}
           `
           github.rest.issues.createComment({
            issue_number: context.issue.number,

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -70,6 +70,14 @@ jobs:
         path: docs/_build/latex/ee-docs.pdf
         if-no-files-found: ignore
 
+#    - name: Upload warnings (on failure)
+#      uses: actions/upload-artifact@v4
+#      if: failure()
+#      with:
+#        name: ee-docs.warnings.log
+#        path: docs/_build/warnings.log
+#        if-no-files-found: ignore
+
     - name: Comment ReadDocs Link in PR
       if: ${{ github.event_name == 'pull_request' }}
       uses: actions/github-script@v7

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,7 +37,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-
+      with:
+        ref: ${{ github.head_ref }}
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,7 +9,7 @@ on:
       - release/*
     paths:
       - docs/**
-  pull_request_target:
+  pull_request:
     types: [issues, opened, reopened, synchronize]
     paths:
       - docs/**

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -70,14 +70,6 @@ jobs:
         path: docs/_build/latex/ee-docs.pdf
         if-no-files-found: ignore
 
-#    - name: Upload warnings (on failure)
-#      uses: actions/upload-artifact@v4
-#      if: failure()
-#      with:
-#        name: ee-docs.warnings.log
-#        path: docs/_build/warnings.log
-#        if-no-files-found: ignore
-
     - name: Comment ReadDocs Link in PR
       if: ${{ github.event_name == 'pull_request' }}
       uses: actions/github-script@v7

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,8 +37,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
+
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -1050,7 +1050,7 @@ These scripts can be combined into a single script using arguments.
 
 **Example 12: modulefiles/build_pmb.module (to be loaded prior to compilation)**
 
-.. code-block:: lua
+.. code-block:: bash
 
    --%Module####################################################
    --                                                 First.Last@noaa.gov


### PR DESCRIPTION
At present, the workflow job "Comment ReadDocs Link in PR" is not running.

This PR attempts to resolve this.