### PR TITLE
Add release branch name, tag, and expectations for code procurement

### DIFF
--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -671,23 +671,38 @@ procurement:
 
 Code must exist on a release branch. 
 
-* :ref:`Release branch names <req-release-branch-name>` will follow the naming convention: ``release/vX.Y.Z``
+* :ref:`Release branch names <req-release-branch-name>` will follow one of the following naming conventions: 
+  * For code that is intended for review by the NCO SPA team, use ``release/vX.Y``
+  * For code that is approved for production, use ``release/vX.Y.Z``
+  * For repositories that support more than one model, use ``release/<model_name>.vX.Y[.Z]>``
 
 .. _req-release-tag-name:
 
 The release branch must have a corresponding release tag.
 
-*  :ref:`Release tag names <req-release-tag-name>` will follow the naming convention: ``<model_name>.vX.Y.Z``
+*  :ref:`Release tag names <req-release-tag-name>` will follow one of the following naming conventions:
+  * For code that is intended for review by the NCO SPA team, use ``<model_name>.vX.Y.rc<N>``
+  * For code that is approved for production, use ``<model_name>.vX.Y.Z``
 
 .. _req-release-procurement:
 
-NCO SPA team members must be able to :ref:`procure code deliveres <req-release-procurement>` with the following git commands:
+NCO SPA team members must be able to :ref:`procure code deliveres <req-release-procurement>` with the following git commands.
+
+For code that is intended for review by the NCO SPA team:
 
 .. code-block:: bash
 
-   $ git clone git@github.com:<organization>/<model_name>.git <model>.vX.Y.Z
+   $ git clone git@github.com:<organization>/<repo_name>.git <model_name>.vX.Y.rc<N>
+   $ cd <model_name>.vX.Y.rc<N>
+   $ git checkout release/vX.Y
+
+For code that is approved for production:
+
+.. code-block:: bash
+
+   $ git clone git@github.com:<organization>/<repo_name>.git <model_name>.vX.Y.Z
    $ cd <model_name>.vX.Y.Z
-   $ git checkout tags/<model_name>.vX.Y.Z -b release/v.X.Y.Z
+   $ git checkout tags/<model_name>.vX.Y.Z
 
 B. Source Code Compilation (C or Fortran)
 -----------------------------------------

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -663,7 +663,9 @@ Code Delivery and Vertical Structure
 
 A. Code Delivery
 ----------------
-The following requirements apply to production code deliveries to NCO:
+
+Production code is to be delivered via git with the following requirements on naming conventions and 
+procurement:
 
 .. _req-release-branch-name:
 
@@ -681,11 +683,11 @@ The release branch must have a corresponding release tag.
 
 NCO SPA team members must be able to acquire code deliveries with the following git commands:
 
-.. codeblock:: bash
+.. code-block:: bash
 
-$ git clone git@github.com:<organization>/<model_name>.git <model>.vX.Y.Z
-$ cd <model_name>.vX.Y.Z
-$ git checkout tags/<model_name>.vX.Y.Z -b release/v.X.Y.Z
+   $ git clone git@github.com:<organization>/<model_name>.git <model>.vX.Y.Z
+   $ cd <model_name>.vX.Y.Z
+   $ git checkout tags/<model_name>.vX.Y.Z -b release/v.X.Y.Z
 
 B. Source Code Compilation (C or Fortran)
 -----------------------------------------
@@ -1241,8 +1243,8 @@ Itemized List of Standards
 
 * :ref:`code-delivery-structure`
 
-  * :ref:`req-release-branch-name`
+  * :ref:`Release branch names <req-release-branch-name>`
 
-  * :ref:`req-release-tag-name`
+  * :ref:`Release tag names <req-release-tag-name>`
 
-  * :ref:`req-release-procurement`
+  * :ref:`Code delivery procurement <req-release-procurement>`

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -672,6 +672,7 @@ procurement:
 Code must exist on a release branch. 
 
 * :ref:`Release branch names <req-release-branch-name>` will follow one of the following naming conventions: 
+
   * For code that is intended for review by the NCO SPA team, use ``release/vX.Y``
   * For code that is approved for production, use ``release/vX.Y.Z``
   * For repositories that support more than one model, use ``release/<model_name>.vX.Y[.Z]>``
@@ -680,7 +681,8 @@ Code must exist on a release branch.
 
 The release branch must have a corresponding release tag.
 
-*  :ref:`Release tag names <req-release-tag-name>` will follow one of the following naming conventions:
+* :ref:`Release tag names <req-release-tag-name>` will follow one of the following naming conventions:
+
   * For code that is intended for review by the NCO SPA team, use ``<model_name>.vX.Y.rc<N>``
   * For code that is approved for production, use ``<model_name>.vX.Y.Z``
 

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -663,9 +663,9 @@ Code Delivery and Vertical Structure
 
 A. Code Delivery
 ----------------
+All new packages will be delivered via git-based services.
 
-Production code is to be delivered via git with the following requirements on naming conventions and 
-procurement:
+Production code delivered via git will be held to the following requirements on naming conventions and procurement:
 
 .. _req-release-branch-name:
 

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -656,7 +656,7 @@ Example call:
    "Job Name [ ``$job`` ]","Name of the process that alerted the file, this is only used in the log output. It can be helpful when trying to identify the job that called ``dbn_alert``"
    "File [ ``$COMOUT/$outputfile`` ]","File to be alerted; must include the full path."
 
-.. _code_delivery_structure:
+.. _code-delivery-structure:
 
 Code Delivery and Vertical Structure
 ====================================
@@ -667,7 +667,7 @@ The following requirements apply to production code deliveries to NCO:
 
 .. _req-release-branch-name:
 
-* Code must exist on a release branch.
+* Code must exist on a release branch. 
 
   * Release branch names will follow the naming convention: ``release/vX.Y.Z``
 
@@ -677,15 +677,12 @@ The following requirements apply to production code deliveries to NCO:
 
   *  Release tags will follow the naming convention: ``<model_name>.vX.Y.Z``
 
-.. _req-release-obtain:
+.. _req-release-procurement:
 
-* NCO SPA team members must be able to acquire your code with the following git commands:
-
-``$ git clone git@github.com:<organization>/<model_name>.git <model>.vX.Y.Z``
-
-``$ cd <model_name>.vX.Y.Z``
-
-``$ git checkout tags/<model_name>.vX.Y.Z -b release/v.X.Y.Z``
+* NCO SPA team members must be able to acquire code deliveries with the following git commands::
+$ git clone git@github.com:<organization>/<model_name>.git <model>.vX.Y.Z
+$ cd <model_name>.vX.Y.Z
+$ git checkout tags/<model_name>.vX.Y.Z -b release/v.X.Y.Z
 
 B. Source Code Compilation (C or Fortran)
 -----------------------------------------
@@ -1234,3 +1231,15 @@ Appendix B: Variables and Directory Structure Tables
 
 
 *TTT* and *SSS* correspond to the 3-digit BUFR data category type and sub-type, respectively
+
+
+Itemized List of Standards
+==========================
+
+* :ref:`code-delivery-structure`
+
+  * :ref:`req-release-branch-name`
+
+  * :ref:`req-release-tag-name`
+
+  * :ref:`req-release-procurement`

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -661,11 +661,33 @@ Example call:
 Code Delivery and Vertical Structure
 ====================================
 
-All components of an application to be run in the NCO production environment must be delivered to IDSB's Senior Production Analysts (SPA) via subversion, git or any other version control system that WCOSS has access to.
-When modifying an application that is already in production, always begin with the most recent production version at ``https://svnwcoss.ncep.noaa.gov/MODEL/tags/``.
+A. Code Delivery
+----------------
+The following requirements apply to production code deliveries to NCO:
 
+.. _req-release-branch-name:
 
-A. Source Code Compilation (C or Fortran)
+* Code must exist on a release branch.
+
+  * Release branch names will follow the naming convention: ``release/vX.Y.Z``
+
+.. _req-release-tag-name:
+
+* The release branch must have a corresponding release tag.
+
+  *  Release tags will follow the naming convention: ``<model_name>.vX.Y.Z``
+
+.. _req-release-obtain:
+
+* NCO SPA team members must be able to acquire your code with the following git commands:
+
+``$ git clone git@github.com:<organization>/<model_name>.git <model>.vX.Y.Z``
+
+``$ cd <model_name>.vX.Y.Z``
+
+``$ git checkout tags/<model_name>.vX.Y.Z -b release/v.X.Y.Z``
+
+B. Source Code Compilation (C or Fortran)
 -----------------------------------------
 
 The directory structure, compilation scripts, makefiles, and documentation for building must be understandable to someone unfamiliar with the specifics of your model.
@@ -695,7 +717,7 @@ Do not deliver pre-built executables or libraries to IDSB. It is the SPA's respo
 * Clear, concise instructions (see Example 10 in `Appendix A: Workflow Examples`_) will reduce confusion and errors if it becomes necessary to rebuild the executable quickly.
 
 
-B. Directory Structures
+C. Directory Structures
 -----------------------
 
 All components of an application to be implemented into the production environment are required to be in vertical structure, where, with the exception of system or standard production libraries and input data, all of the files required to completely build and run the jobs are contained in an application-specific package.
@@ -776,7 +798,7 @@ Table 5 (below), Table 7, Table 8, and Table 9 (in `Appendix B: Variables and Di
 
 
 
-C. Unresolved Bugs
+D. Unresolved Bugs
 ------------------
 
 Before handing off code to NCO, all Bugzilla entries must be addressed.

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -667,19 +667,22 @@ The following requirements apply to production code deliveries to NCO:
 
 .. _req-release-branch-name:
 
-* Code must exist on a release branch. 
+Code must exist on a release branch. 
 
-  * Release branch names will follow the naming convention: ``release/vX.Y.Z``
+* Release branch names will follow the naming convention: ``release/vX.Y.Z``
 
 .. _req-release-tag-name:
 
-* The release branch must have a corresponding release tag.
+The release branch must have a corresponding release tag.
 
-  *  Release tags will follow the naming convention: ``<model_name>.vX.Y.Z``
+*  Release tags will follow the naming convention: ``<model_name>.vX.Y.Z``
 
 .. _req-release-procurement:
 
-* NCO SPA team members must be able to acquire code deliveries with the following git commands::
+NCO SPA team members must be able to acquire code deliveries with the following git commands:
+
+.. codeblock:: bash
+
 $ git clone git@github.com:<organization>/<model_name>.git <model>.vX.Y.Z
 $ cd <model_name>.vX.Y.Z
 $ git checkout tags/<model_name>.vX.Y.Z -b release/v.X.Y.Z

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -663,9 +663,9 @@ Code Delivery and Vertical Structure
 
 A. Code Delivery
 ----------------
-All new packages will be delivered via git-based services.
+All new packages will be delivered via git-based services (e.g. GitHub, GitLab).
 
-Production code delivered via git will be held to the following requirements on naming conventions and procurement:
+Production code delivered via git (and hosted on GitHub) will be held to the following requirements on naming conventions and procurement:
 
 .. _req-release-branch-name:
 

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -671,17 +671,17 @@ procurement:
 
 Code must exist on a release branch. 
 
-* Release branch names will follow the naming convention: ``release/vX.Y.Z``
+* :ref:`Release branch names <req-release-branch-name>` will follow the naming convention: ``release/vX.Y.Z``
 
 .. _req-release-tag-name:
 
 The release branch must have a corresponding release tag.
 
-*  Release tags will follow the naming convention: ``<model_name>.vX.Y.Z``
+*  :ref:`Release tag names <req-release-tag-name>` will follow the naming convention: ``<model_name>.vX.Y.Z``
 
 .. _req-release-procurement:
 
-NCO SPA team members must be able to acquire code deliveries with the following git commands:
+NCO SPA team members must be able to :ref:`procure code deliveres <req-release-procurement>` with the following git commands:
 
 .. code-block:: bash
 
@@ -1236,15 +1236,3 @@ Appendix B: Variables and Directory Structure Tables
 
 
 *TTT* and *SSS* correspond to the 3-digit BUFR data category type and sub-type, respectively
-
-
-Itemized List of Standards
-==========================
-
-* :ref:`code-delivery-structure`
-
-  * :ref:`Release branch names <req-release-branch-name>`
-
-  * :ref:`Release tag names <req-release-tag-name>`
-
-  * :ref:`Code delivery procurement <req-release-procurement>`


### PR DESCRIPTION
Started from RussellManser-NCO:feature/branch_standards

Streamlined and added links.

@RussellManser-NCO sorry for the second PR here. I wasn't able to push my changes back to your fork. We can work that out later. Really just preserving edits here, but PR to test doc build and test links.