### PR TITLE
Add NCO issue labels

### DIFF
--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -829,13 +829,12 @@ i. Issue Tracking on Remote Hosting Services
    :widths: auto
 
    "NCO Issue Label","Description"
-   "NCO: Bug","A bug that was identified in production code or during NCO review"
-   "NCO: Standards","An item in the standards document needs to be addressed"
-   "NCO: Enhancement","A suggested improvement from NCO" 
-   "NCO Status: New","An NCO issue that has yet to be worked on by the development team"
+   "NCO Type: Bug","A bug that was identified in production code or during NCO review"
+   "NCO Type: Standards","An item in the standards document needs to be addressed"
+   "NCO Type: Enhancement","A suggested improvement from NCO" 
+   "NCO Status: Open","An NCO issue that has yet to be worked on by the development team"
    "NCO Status: In Progress","An NCO issue that is actively being worked on"
-   "NCO Status: Pending Review","An NCO issue that has been addressed, but requires review from NCO SPA team member"
-   "NCO Status: Approved","An NCO issue that has been approved as fixed by an NCO SPA team member"
+   "NCO Status: Review Required","An NCO issue that has been addressed, but requires review from NCO SPA team member"
 
 Before handing off code to NCO, all NCO labeled issues must be addressed.
 Please mark all items that have been resolved with "NCO Status: Pending Review" and add a brief, but complete explanation of the resolution, including a link to a pull request which addresses the issue.

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -821,7 +821,7 @@ D. NCO Labeled Issues and Bugzilla Bugs
 ------------------------------
 Before handing off code to NCO, all pre-existing NCO labeled issues and/or Bugzilla Bugs (hereafter simply "Bugzillas") must be addressed.
 
-The SPA will then verify the fix during testing and close the issue/Bug following implementation.
+The SPA will then verify the fix during testing and close the issue/Bugzilla following implementation.
 
 If an NCO labeled issue or Bugzilla cannot be resolved, justification must be added in a comment on the issue/Bugzilla and approval received from the SPA Team Lead.
 

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -817,8 +817,13 @@ Table 5 (below), Table 7, Table 8, and Table 9 (in `Appendix B: Variables and Di
 
 
 
-D. NCO Labeled Issues and Bugs
+D. NCO Labeled Issues and Bugzilla Bugs
 ------------------------------
+Before handing off code to NCO, all pre-existing NCO labeled issues and/or Bugzilla Bugs (hereafter simply "Bugs") must be addressed.
+
+The SPA will then verify the fix during testing and close the issue/Bug following implementation.
+
+If an NCO labeled issue or Bug cannot be resolved, justification must be added in a comment on the issue/Bug and approval received from the SPA Team Lead.
 
 i. Issue Tracking on Remote Hosting Services
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -836,19 +841,14 @@ i. Issue Tracking on Remote Hosting Services
    "NCO Status: In Progress","An NCO issue that is actively being worked on"
    "NCO Status: Review Required","An NCO issue that has been addressed, but requires review from NCO SPA team member"
 
-Before handing off code to NCO, all NCO labeled issues must be addressed.
-Please mark all items that have been resolved with "NCO Status: Pending Review" and add a brief, but complete explanation of the resolution, including a link to a pull request which addresses the issue.
-The SPA will then verify the fix during testing and close the issue following implementation.
-If an NCO labeled issue cannot be resolved, justification must be added in a comment on the issue and approval received from the SPA team lead.
+Please mark all items that have been resolved with "NCO Status: Review Required" and explain the resolution, including a link to a pull request which addresses the issue.
 
 ii. Bugzillas
 ^^^^^^^^^^^^^
 
-NCO will be transitioning from Bugzilla reports to issue tracking on remote hosting services (e.g., GitHub).
-During this transition, all Bugzillas must still be addressed before code handoff to NCO.
-Please continue to mark all Bugzillas that have been resolved as such and add a brief, but complete explanation of the resolution, including relevant files modified to address the bug.
-The SPA will then verify the fix during testing and close the bug following implementation.
-If a bug cannot be resolved, a comment must be added and approval received from the SPA team lead.
+NCO will be transitioning from Bugzilla to issue tracking on remote hosting services (e.g., GitHub).
+
+Please continue to mark all Bugzilla Bugs that have been resolved as such and explain the resolution, including relevant files modified to address the bug.
 
 
 .. _appendices:

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -831,6 +831,7 @@ i. Issue Tracking on Remote Hosting Services
    "NCO Issue Label","Description"
    "NCO: Bug","A bug that was identified in production code or during NCO review"
    "NCO: Standards","An item in the standards document needs to be addressed"
+   "NCO: Enhancement","A suggested improvement from NCO" 
    "NCO Status: New","An NCO issue that has yet to be worked on by the development team"
    "NCO Status: In Progress","An NCO issue that is actively being worked on"
    "NCO Status: Pending Review","An NCO issue that has been addressed, but requires review from NCO SPA team member"

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -820,6 +820,9 @@ Table 5 (below), Table 7, Table 8, and Table 9 (in `Appendix B: Variables and Di
 D. NCO Labeled Issues and Bugs
 ------------------------------
 
+i. Issue Tracking on Remote Hosting Services
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 .. csv-table::
    :header-rows: 1
    :stub-columns: 0
@@ -837,6 +840,15 @@ Before handing off code to NCO, all NCO labeled issues must be addressed.
 Please mark all items that have been resolved with "NCO Status: Pending Review" and add a brief, but complete explanation of the resolution, including a link to a pull request which addresses the issue.
 The SPA will then verify the fix during testing and close the issue following implementation.
 If an NCO labeled issue cannot be resolved, justification must be added in a comment on the issue and approval received from the SPA team lead.
+
+ii. Bugzillas
+^^^^^^^^^^^^^
+
+NCO will be transitioning from Bugzilla reports to issue tracking on remote hosting services (e.g., GitHub).
+During this transition, all Bugzillas must still be addressed before code handoff to NCO.
+Please continue to mark all Bugzillas that have been resolved as such and add a brief, but complete explanation of the resolution, including relevant files modified to address the bug.
+The SPA will then verify the fix during testing and close the bug following implementation.
+If a bug cannot be resolved, a comment must be added and approval received from the SPA team lead.
 
 
 .. _appendices:

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -817,13 +817,27 @@ Table 5 (below), Table 7, Table 8, and Table 9 (in `Appendix B: Variables and Di
 
 
 
-D. Unresolved Bugs
-------------------
+D. NCO Labeled Issues and Bugs
+------------------------------
 
-Before handing off code to NCO, all Bugzilla entries must be addressed.
-Please mark all items that have been resolved as such and add a brief complete explanation of the resolution, including relevant files modified to address the bug.
-The SPA will then verify the fix during testing and close the bug following implementation.
-If a bug cannot be resolved, a comment must be added and approval received from the SPA team lead.
+.. csv-table::
+   :header-rows: 1
+   :stub-columns: 0
+   :widths: auto
+
+   "NCO Issue Label","Description"
+   "NCO: Bug","A bug that was identified in production code or during NCO review"
+   "NCO: EE2","An item in the EE2 checklist needs to be addressed"
+   "NCO: Standards","An item in the standards document needs to be addressed"
+   "NCO Status: New","An NCO issue that has yet to be worked on by the development team"
+   "NCO Status: In Progress","An NCO issue that is actively being worked on"
+   "NCO Status: Pending Review","An NCO issue that has been addressed, but requires review from NCO SPA team member"
+   "NCO Status: Approved","An NCO issue that has been approved as fixed by an NCO SPA team member"
+
+Before handing off code to NCO, all NCO labeled issues must be addressed.
+Please mark all items that have been resolved with "NCO Status: Pending Review" and add a brief, but complete explanation of the resolution, including a link to a pull request which addresses the issue.
+The SPA will then verify the fix during testing and close the issue following implementation.
+If an NCO labeled issue cannot be resolved, justification must be added in a comment on the issue and approval received from the SPA team lead.
 
 
 .. _appendices:

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -827,7 +827,6 @@ D. NCO Labeled Issues and Bugs
 
    "NCO Issue Label","Description"
    "NCO: Bug","A bug that was identified in production code or during NCO review"
-   "NCO: EE2","An item in the EE2 checklist needs to be addressed"
    "NCO: Standards","An item in the standards document needs to be addressed"
    "NCO Status: New","An NCO issue that has yet to be worked on by the development team"
    "NCO Status: In Progress","An NCO issue that is actively being worked on"

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -819,11 +819,11 @@ Table 5 (below), Table 7, Table 8, and Table 9 (in `Appendix B: Variables and Di
 
 D. NCO Labeled Issues and Bugzilla Bugs
 ------------------------------
-Before handing off code to NCO, all pre-existing NCO labeled issues and/or Bugzilla Bugs (hereafter simply "Bugs") must be addressed.
+Before handing off code to NCO, all pre-existing NCO labeled issues and/or Bugzilla Bugs (hereafter simply "Bugzillas") must be addressed.
 
 The SPA will then verify the fix during testing and close the issue/Bug following implementation.
 
-If an NCO labeled issue or Bug cannot be resolved, justification must be added in a comment on the issue/Bug and approval received from the SPA Team Lead.
+If an NCO labeled issue or Bugzilla cannot be resolved, justification must be added in a comment on the issue/Bugzilla and approval received from the SPA Team Lead.
 
 i. Issue Tracking on Remote Hosting Services
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -848,7 +848,7 @@ ii. Bugzillas
 
 NCO will be transitioning from Bugzilla to issue tracking on remote hosting services (e.g., GitHub).
 
-Please continue to mark all Bugzilla Bugs that have been resolved as such and explain the resolution, including relevant files modified to address the bug.
+Please continue to mark all Bugzillas that have been resolved as such and explain the resolution, including relevant files modified to address the Bugzilla.
 
 
 .. _appendices:


### PR DESCRIPTION
This PR adds NCO issue labels to the standards document to replace bug reports via Bugzilla. Please feel free to discuss and provide feedback.

You can find the build for this PR [here](https://nws-hpc-standards--32.org.readthedocs.build/en/32/standards.html#d-nco-labeled-issues-and-bugs).

Closes #31 