### PR TITLE
Upgrades start with the most recent version of the production application

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,7 +30,8 @@ jobs:
 
     permissions:
       pull-requests: "write"
-      contents: "read"
+      issues: "write"
+      contents: "write"
 
     runs-on: ubuntu-latest
     name: Build and deploy documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Comment ReadDocs Link in PR
       if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const message = `

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Comment ReadDocs Link in PR
       if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@v7
       with:
         script: |
           const message = `

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,6 +30,7 @@ jobs:
 
     permissions:
       pull-requests: "write"
+      issues: "write"
 
     runs-on: ubuntu-latest
     name: Build and deploy documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,7 +30,7 @@ jobs:
 
     permissions:
       pull-requests: "write"
-      issues: "write"
+      contents: "read"
 
     runs-on: ubuntu-latest
     name: Build and deploy documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,8 +30,6 @@ jobs:
 
     permissions:
       pull-requests: "write"
-      issues: "write"
-      contents: "write"
 
     runs-on: ubuntu-latest
     name: Build and deploy documentation

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -664,7 +664,8 @@ Code Delivery and Vertical Structure
 
 A. Code Delivery
 ----------------
-All new packages will be delivered via git-based services (e.g. GitHub, GitLab).
+All new packages will be delivered via git-based services (e.g. GitHub, GitLab). When upgrading an existing production application, 
+always introduce changes by modifying the most recent production version.
 
 Production code delivered via git (and hosted on GitHub) will be held to the following requirements on naming conventions and procurement:
 

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -666,6 +666,7 @@ A. Code Delivery
 ----------------
 
 Delivered code must:
+
 * contain any production bug fixes implemented since the last code delivery.
 * only contain changes that were defined at project kickoff, and are needed for the production environment.
 

--- a/docs/standards.rst
+++ b/docs/standards.rst
@@ -664,8 +664,12 @@ Code Delivery and Vertical Structure
 
 A. Code Delivery
 ----------------
-All new packages will be delivered via git-based services (e.g. GitHub, GitLab). When upgrading an existing production application, 
-always introduce changes by modifying the most recent production version.
+
+Delivered code must:
+* contain any production bug fixes implemented since the last code delivery.
+* only contain changes that were defined at project kickoff, and are needed for the production environment.
+
+All new packages will be delivered via git-based services (e.g. GitHub, GitLab).
 
 Production code delivered via git (and hosted on GitHub) will be held to the following requirements on naming conventions and procurement:
 


### PR DESCRIPTION
Add back the language previously removed via PR #30 which instructs developers submitting an upgrade to begin their upgrade using the most recent version of the production application.

You should see a draft of the built docs, including the proposed change, appear as a comment (by a bot) in this discussion.