### PR TITLE
Add visual diff config for stable/latest

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,14 @@
+{# docs/_templates/layout.html #}
+
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+    {{ super() }}
+    <!-- Enable visual diff between latest and stable -->
+    <script type="application/json" id="doc-diff-config">
+    {
+      "base_url": "/en/stable/index.html",
+      "base_version": "stable"
+    }
+    </script>
+{% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -8,7 +8,9 @@
     <script type="application/json" id="doc-diff-config">
     {
       "base_url": "/en/stable/index.html",
-      "base_version": "stable"
+      "base_version": "stable",
+      "inject_styles": true,
+      "force_init": true
     }
     </script>
 {% endblock %}


### PR DESCRIPTION
This PR attempts to add a visual diff in Read the Docs for stable versus latest versions.

Closes #39 