### PR TITLE
Fix broken action to comment with a link to a PR build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Comment ReadDocs Link in PR
       if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const message = `

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,10 +9,12 @@ on:
       - release/*
     paths:
       - docs/**
+      - .github/workflows/**
   pull_request:
     types: [issues, opened, reopened, synchronize]
     paths:
       - docs/**
+      - .github/workflows/**
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,7 +31,7 @@ jobs:
   documentation:
 
     permissions:
-      pull-requests: "write"
+      pull-requests: ["read", "write"]
 
     runs-on: ubuntu-latest
     name: Build and deploy documentation


### PR DESCRIPTION
Please do not merge this PR yet. I am attempting to trigger the comment action to see if it is broken here.

This PR attempts to fix the broken action to comment a link to a build of the docs in a PR. The behavior appears to differ between PRs from branches on the main repo and PRs opened from branches on forks.

- [x] Fix action for branches on main repo
- [ ] Fix action for branches on forks

Closes #44 